### PR TITLE
Chore/node 19

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 16.x, 14.x, 12.x]
+        node-version: [19.x, 18.x, 16.x, 14.x, 12.x]
         database-type: [postgres, pgnative, mysql, mssql, sqlite3, cockroachdb, better-sqlite3, oracledb]
 
     steps:
@@ -97,7 +97,7 @@ jobs:
     name: Test user experience
     strategy:
       matrix:
-        node-version: [18.x, 16.x, 14.x, 12.x]
+        node-version: [19.x, 18.x, 16.x, 14.x, 12.x]
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
     steps:
       - name: Checkout Repository

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 16.x, 14.x, 12.x]
+        node-version: [19.x, 18.x, 16.x, 14.x, 12.x]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
- Add Node 19 to CI version matrixes for tests
- Use Node 18 for lint task. Previously used Node 16